### PR TITLE
WS API uses query parameters for token, app id, and api version

### DIFF
--- a/src/main/java/com/github/maxopoly/Kira/api/KiraWebSocketServer.java
+++ b/src/main/java/com/github/maxopoly/Kira/api/KiraWebSocketServer.java
@@ -1,6 +1,8 @@
 package com.github.maxopoly.Kira.api;
 
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,24 +17,23 @@ import com.github.maxopoly.Kira.api.token.APIToken;
 import com.github.maxopoly.Kira.api.token.APITokenManager;
 
 public class KiraWebSocketServer extends WebSocketServer {
-	
+
 	private static final int API_VERSION = 1;
-	
+
 	private Map <WebSocket, APISession> connections;
 	private Logger logger;
 
-	
 	public KiraWebSocketServer(Logger logger) {
 		super(new InetSocketAddress("localhost/kira/api",14314));
 		this.logger = logger;
 		connections = new HashMap<>();
 		start();
 	}
-	
+
 	private APISession getAPISession(WebSocket socket) {
 		return connections.get(socket);
 	}
-	
+
 	@Override
 	public void onClose(WebSocket conn, int code, String reason, boolean remote) {
 		KiraMain.getInstance().getLogger().warn("Closing connection with " + conn.getRemoteSocketAddress() + ", because of: " + reason);
@@ -40,7 +41,8 @@ public class KiraWebSocketServer extends WebSocketServer {
 
 	@Override
 	public void onError(WebSocket conn, Exception ex) {
-		KiraMain.getInstance().getLogger().warn("Error occured in API handling of " + conn.getRemoteSocketAddress(), ex);	
+		String remoteAddr = conn == null ? "(no connection)" : conn.getRemoteSocketAddress().toString();
+		KiraMain.getInstance().getLogger().warn("Error occured in API handling of " + remoteAddr, ex);
 	}
 
 	@Override
@@ -61,22 +63,23 @@ public class KiraWebSocketServer extends WebSocketServer {
 	public void onStart() {
 		//already did everything in constructor, but still have to override this
 	}
-	
+
 	private APISession setupSession(WebSocket conn, ClientHandshake handshake) {
-		String tokenString = handshake.getFieldValue("apiToken");
-		if (tokenString.equals("")) {
+		Map<String, String> queryParams = getQueryParams(handshake.getResourceDescriptor());
+		String tokenString = queryParams.get("apiToken");
+		if (tokenString == null || tokenString.equals("")) {
 			logger.info("Closing connection with " + conn.getRemoteSocketAddress() + ", because no api token was given");
 			conn.close(400, "No token supplied");
 			return null;
 		}
-		String appId = handshake.getFieldValue("applicationId");
-		if (appId.equals("")) {
+		String appId = queryParams.get("applicationId");
+		if (appId == null || appId.equals("")) {
 			logger.info("Closing connection with " + conn.getRemoteSocketAddress() + ", because no application id was given");
 			conn.close(400, "No app id supplied");
 			return null;
 		}
-		String versionString = handshake.getFieldValue("apiVersion");
-		if (versionString.equals("")) {
+		String versionString = queryParams.get("apiVersion");
+		if (versionString == null || versionString.equals("")) {
 			logger.info("Closing connection with " + conn.getRemoteSocketAddress() + ", because no api version was given");
 			conn.close(400, "No api version supplied");
 			return null;
@@ -107,5 +110,37 @@ public class KiraWebSocketServer extends WebSocketServer {
 			conn.close(400, "Outdated token");
 		}
 		return token.generateSession(conn);
+	}
+
+	/**
+	 * Takes an URI and returns the last key-value mapping for each query parameter pair.
+	 * If the URI contains no query parameters, returns an empty map.
+	 * Ignores the fragment part of the URI.
+	 * Malformed keys/values (unsupported encoding) are ignored.
+	 * Note that keys are case sensitive as per RFC 3986. https://tools.ietf.org/html/rfc3986#page-11
+	 */
+	public static Map<String, String> getQueryParams(String uri) {
+		Map<String, String> queryPairs = new HashMap<String, String>();
+
+		int paramsSepIdx = uri.indexOf("?");
+		if (paramsSepIdx < 0) return queryPairs; // no query params in URI
+		String query = uri.substring(paramsSepIdx + 1);
+
+		int fragmentSepIdx = query.indexOf("#");
+		if (fragmentSepIdx >= 0) {
+			query = query.substring(0, fragmentSepIdx);
+		}
+
+		String[] pairs = query.split("&");
+		for (String pair : pairs) {
+			int kvSep = pair.indexOf("=");
+			try {
+			String key = URLDecoder.decode(pair.substring(0, kvSep), "UTF-8");
+			String value = URLDecoder.decode(pair.substring(kvSep + 1), "UTF-8");
+			queryPairs.put(key, value);
+			} catch (UnsupportedEncodingException ignored) {
+			}
+		}
+		return queryPairs;
 	}
 }


### PR DESCRIPTION
This change is required to allow web browsers to connect to the API, as they cannot set headers which is required by the current method.

Also fixes NPE in `onError` when `conn == null` (general server errors).

Example URI:
`ws://localhost:14314/?apiVersion=1&apiToken=123abc&applicationId=test-app`

After merging, the API doc will need to be updated, too.