### PR TITLE
announce new player logins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.github.maxopoly</groupId>
 	<artifactId>Kira</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<packaging>jar</packaging>
 
 	<name>Kira</name>

--- a/src/main/java/com/github/maxopoly/kira/api/APISessionManager.java
+++ b/src/main/java/com/github/maxopoly/kira/api/APISessionManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
+import com.github.maxopoly.kira.relay.actions.NewPlayerAction;
 import org.apache.logging.log4j.Logger;
 
 import com.github.maxopoly.kira.api.input.APIInputHandler;
@@ -74,6 +75,14 @@ public class APISessionManager {
 	public void handleSkynetMessage(SkynetAction action) {
 		iterateAndCleanUp(skynetTakers, (session, a) -> {
 			session.sendSkynetAlert(action);
+		}, action);
+	}
+
+	public void handleNewPlayerMessage(NewPlayerAction action) {
+		// reuse skynetTakers because this is from the same event source
+		// and thus visible to the same audience
+		iterateAndCleanUp(skynetTakers, (session, a) -> {
+			session.sendNewPlayerAlert(action);
 		}, action);
 	}
 

--- a/src/main/java/com/github/maxopoly/kira/command/discord/relay/ConfigureRelayConfigCommand.java
+++ b/src/main/java/com/github/maxopoly/kira/command/discord/relay/ConfigureRelayConfigCommand.java
@@ -10,6 +10,7 @@ import com.github.maxopoly.kira.relay.RelayConfig;
 import com.github.maxopoly.kira.relay.RelayConfigManager;
 import com.github.maxopoly.kira.relay.actions.GroupChatMessageAction;
 import com.github.maxopoly.kira.relay.actions.MinecraftLocation;
+import com.github.maxopoly.kira.relay.actions.NewPlayerAction;
 import com.github.maxopoly.kira.relay.actions.PlayerHitSnitchAction;
 import com.github.maxopoly.kira.relay.actions.SkynetAction;
 import com.github.maxopoly.kira.relay.actions.SkynetType;
@@ -88,6 +89,8 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				+ "relayconfig [name] skynetlogoutformat [your login message]\n"
 				+ "relayconfig [name] skynetformat [your skynet format]\n"
 				+ "relayconfig [name] skynetenabled [true|false]\n"
+				+ "relayconfig [name] newplayerformat [your new player announcement format]\n"
+				+ "relayconfig [name] newplayerenabled [true|false]\n"
 				+ "relayconfig [name] timeformat [your time format like HH:mm:ss]";
 	}
 
@@ -154,6 +157,12 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 					+ "\n");
 			reply.append(" - Skynet login format (skynetloginformat): " + relay.getSkynetLoginString() + "\n");
 			reply.append(" - Skynet logout format (skynetlogoutformat): " + relay.getSkynetLogoutString() + "\n");
+			reply.append(" - Relaying of new player logins (newplayerenabled): "
+					+ relay.isNewPlayerEnabled() + "\n");
+			reply.append(" - new player announcement format (newplayerformat): " + relay.getNewPlayerFormat() + "\n");
+			reply.append("    Example: "
+					+ relay.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "ttk2"))
+					+ "\n");
 			reply.append(" - Use \"help relayconfig\" for more information on how to configure these properties\n");
 			return reply.toString();
 		}
@@ -340,6 +349,23 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				reply.append("Example skynet logout message would look like this:\n");
 				reply.append(relay
 						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "ttk2", SkynetType.LOGOUT)));
+				reply.append('\n');
+			}
+			break;
+		case "newplayerenabled":
+			Boolean newPlayerEnabled = attemptBooleanParsing(arguments, reply);
+			if (newPlayerEnabled != null) {
+				relay.updateNewPlayerEnabled(newPlayerEnabled);
+				reply.append("Setting new player announcements status to: " + relay.isNewPlayerEnabled());
+			}
+			break;
+		case "newplayerformat":
+			if (passLengthCheck(arguments, 512, reply)) {
+				reply.append("Setting new player announcements format to: " + arguments + "\n");
+				relay.updateNewPlayerFormat(arguments);
+				reply.append("Example new player announcements message would look like this:\n");
+				reply.append(relay
+						.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "ttk2")));
 				reply.append('\n');
 			}
 			break;

--- a/src/main/java/com/github/maxopoly/kira/rabbit/RabbitInputProcessor.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/RabbitInputProcessor.java
@@ -8,6 +8,7 @@ import com.github.maxopoly.kira.rabbit.input.AddAuthMessage;
 import com.github.maxopoly.kira.rabbit.input.ConsoleForwardMessage;
 import com.github.maxopoly.kira.rabbit.input.CreateGroupChatMessage;
 import com.github.maxopoly.kira.rabbit.input.DeleteGroupChatMessage;
+import com.github.maxopoly.kira.rabbit.input.NewPlayerMessage;
 import com.github.maxopoly.kira.rabbit.input.ReplyToUserMessage;
 import com.github.maxopoly.kira.rabbit.input.RequestSessionReplyMessage;
 import com.github.maxopoly.kira.rabbit.input.SendGroupChatMessage;
@@ -43,6 +44,7 @@ public class RabbitInputProcessor extends JsonInputHandler<RabbitInputSupplier> 
 		registerCommand(new SnitchHitMessage());
 		registerCommand(new RequestSessionReplyMessage());
 		registerCommand(new SkynetMessage());
+		registerCommand(new NewPlayerMessage());
 		registerCommand(new ConsoleForwardMessage(KiraMain.getInstance().getConfig().getConsoleForwardingMapping()));
 	}
 

--- a/src/main/java/com/github/maxopoly/kira/rabbit/input/NewPlayerMessage.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/input/NewPlayerMessage.java
@@ -1,0 +1,24 @@
+package com.github.maxopoly.kira.rabbit.input;
+
+import com.github.maxopoly.kira.KiraMain;
+import com.github.maxopoly.kira.rabbit.RabbitInputSupplier;
+import com.github.maxopoly.kira.relay.actions.NewPlayerAction;
+import org.json.JSONObject;
+
+public class NewPlayerMessage extends RabbitMessage {
+
+    public NewPlayerMessage() {
+        super("newplayer");
+    }
+
+    @Override
+    public void handle(JSONObject json, RabbitInputSupplier supplier) {
+        String player = json.getString("player");
+        long timestamp = json.optLong("timestamp", System.currentTimeMillis());
+        NewPlayerAction action = new NewPlayerAction(timestamp, player);
+        KiraMain.getInstance().getAPISessionManager().handleNewPlayerMessage(action);
+        KiraMain.getInstance().getGroupChatManager().applyToAll(chat -> {
+            chat.sendNewPlayer(action);
+        });
+    }
+}

--- a/src/main/java/com/github/maxopoly/kira/relay/GroupChat.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/GroupChat.java
@@ -2,6 +2,7 @@ package com.github.maxopoly.kira.relay;
 
 import com.github.maxopoly.kira.permission.KiraRole;
 import com.github.maxopoly.kira.relay.actions.GroupChatMessageAction;
+import com.github.maxopoly.kira.relay.actions.NewPlayerAction;
 import com.github.maxopoly.kira.relay.actions.PlayerHitSnitchAction;
 import com.github.maxopoly.kira.relay.actions.SkynetAction;
 import com.github.maxopoly.kira.user.KiraUser;
@@ -102,7 +103,25 @@ public class GroupChat {
 		channel.sendMessage(msg).queue();
 		return true;
 	}
-	
+
+	public boolean sendNewPlayer(NewPlayerAction action) {
+		if (!config.isNewPlayerEnabled()) {
+			return true;
+		}
+		JDA jda = KiraMain.getInstance().getJDA();
+		Guild guild = jda.getGuildById(guildId);
+		if (guild == null) {
+			return false;
+		}
+		TextChannel channel = guild.getTextChannelById(channelId);
+		if (channel == null) {
+			return false;
+		}
+		String msg = config.formatNewPlayerMessage(action);
+		channel.sendMessage(msg).queue();
+		return true;
+	}
+
 	public boolean sendSnitchHit(PlayerHitSnitchAction action) {
 		JDA jda = KiraMain.getInstance().getJDA();
 		Guild guild = jda.getGuildById(guildId);

--- a/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import com.github.maxopoly.kira.relay.actions.GroupChatMessageAction;
 import com.github.maxopoly.kira.relay.actions.MinecraftLocation;
+import com.github.maxopoly.kira.relay.actions.NewPlayerAction;
 import com.github.maxopoly.kira.relay.actions.PlayerHitSnitchAction;
 import com.github.maxopoly.kira.relay.actions.SkynetAction;
 import com.github.maxopoly.kira.KiraMain;
@@ -35,13 +36,15 @@ public class RelayConfig {
 	private String skynetLogoutString;
 	private String skynetFormat;
 	private boolean skynetEnabled;
+	private String newPlayerFormat;
+	private boolean newPlayerEnabled;
 	private int ownerID;
 
 	public RelayConfig(int id, String name, boolean relayFromDiscord, boolean relayToDiscord, boolean showSnitches,
 			boolean deleteDiscordMessages, String snitchHitFormat, String loginString, String logoutString,
 			String enterString, String chatFormat, String hereFormat, String everyoneFormat, boolean shouldPing,
 			String timeFormat, String skynetLoginString, String skynetLogoutString, String skynetFormat,
-			boolean skynetEnabled, int ownerID) {
+			boolean skynetEnabled, String newPlayerFormat, boolean newPlayerEnabled, int ownerID) {
 		this.relayFromDiscord = relayFromDiscord;
 		this.id = id;
 		this.name = name;
@@ -64,6 +67,8 @@ public class RelayConfig {
 		this.skynetLogoutString = skynetLogoutString;
 		this.skynetFormat = skynetFormat;
 		this.skynetEnabled = skynetEnabled;
+		this.newPlayerFormat = newPlayerFormat;
+		this.newPlayerEnabled = newPlayerEnabled;
 		this.herePattern = Pattern.compile(hereFormat);
 		this.everyonePattern = Pattern.compile(everyoneFormat);
 	}
@@ -92,6 +97,14 @@ public class RelayConfig {
 			throw new IllegalArgumentException();
 		}
 		output = output.replace("%ACTION%", actionString);
+		output = output.replace("%PLAYER%", action.getPlayer());
+		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
+		output = reformatPings(output);
+		return output;
+	}
+
+	public String formatNewPlayerMessage(NewPlayerAction action) {
+		String output = newPlayerFormat;
 		output = output.replace("%PLAYER%", action.getPlayer());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
 		output = reformatPings(output);
@@ -167,6 +180,10 @@ public class RelayConfig {
 		return skynetLogoutString;
 	}
 
+	public String getNewPlayerFormat() {
+		return newPlayerFormat;
+	}
+
 	public String getSnitchEnterString() {
 		return snitchEnterString;
 	}
@@ -189,6 +206,10 @@ public class RelayConfig {
 
 	public boolean isSkynetEnabled() {
 		return skynetEnabled;
+	}
+
+	public boolean isNewPlayerEnabled() {
+		return newPlayerEnabled;
 	}
 
 	private String reformatPings(String output) {
@@ -309,6 +330,16 @@ public class RelayConfig {
 
 	public void updateSkynetLogoutString(String skynetLogoutString) {
 		this.skynetLogoutString = skynetLogoutString;
+		KiraMain.getInstance().getDAO().updateRelayConfig(this);
+	}
+
+	public void updateNewPlayerEnabled(boolean newPlayerEnabled) {
+		this.newPlayerEnabled = newPlayerEnabled;
+		KiraMain.getInstance().getDAO().updateRelayConfig(this);
+	}
+
+	public void updateNewPlayerFormat(String newPlayerFormat) {
+		this.newPlayerFormat = newPlayerFormat;
 		KiraMain.getInstance().getDAO().updateRelayConfig(this);
 	}
 

--- a/src/main/java/com/github/maxopoly/kira/relay/RelayConfigManager.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/RelayConfigManager.java
@@ -45,7 +45,7 @@ public class RelayConfigManager {
 				"`[%TIME%]` `[%GROUP%]` **[%PLAYER%]** %MESSAGE% %PING%",
 				"`[%TIME%]` `[%GROUP%]` **%PLAYER%** %ACTION% at %SNITCH% (%X%,%Y%,%Z%) %PING%", "logged in", "logged out",
 				"is", "@here", "@everyone", false, "HH:mm:ss", "`[%TIME%]` **%PLAYER%** %ACTION%", "logged in",
-				"logged out", false, creator);
+				"logged out", false, "`[%TIME%]` **%PLAYER%** is brand new!", false, creator);
 		if (config == null) {
 			return null;
 		}

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/NewPlayerAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/NewPlayerAction.java
@@ -1,0 +1,23 @@
+package com.github.maxopoly.kira.relay.actions;
+
+import org.json.JSONObject;
+
+public class NewPlayerAction extends MinecraftAction {
+
+	private String player;
+
+	public NewPlayerAction(long timestamp, String player) {
+		super(timestamp);
+		this.player = player;
+	}
+
+	public String getPlayer() {
+		return player;
+	}
+
+	@Override
+	protected void internalConstructJSON(JSONObject json) {
+		json.put("player", player);
+	}
+
+}

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/SkynetAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/SkynetAction.java
@@ -3,20 +3,20 @@ package com.github.maxopoly.kira.relay.actions;
 import org.json.JSONObject;
 
 public class SkynetAction extends MinecraftAction {
-	
+
 	private SkynetType type;
 	private String player;
-	
+
 	public SkynetAction(long timestamp, String player, SkynetType type) {
 		super(timestamp);
 		this.player = player;
 		this.type = type;
 	}
-	
+
 	public String getPlayer() {
 		return player;
 	}
-	
+
 	public SkynetType getType() {
 		return type;
 	}
@@ -24,7 +24,7 @@ public class SkynetAction extends MinecraftAction {
 	@Override
 	protected void internalConstructJSON(JSONObject json) {
 		json.put("player", player);
-		json.put("action", type.toString());		
+		json.put("action", type.toString());
 	}
 
 }


### PR DESCRIPTION
- uses `relayconfig` command to enable and customize format, persisting to DB
- uses `SKYNET` API scope, sending announcements to `new-players` array

DB needs additional columns in `relay_configs`: `newPlayerFormat text not null, relayNewPlayer boolean not null`  
with `newPlayerFormat` defaulting to "\`[%TIME%]\` \*\*%PLAYER%\*\* is brand new!"  
and `relayNewPlayer` defaulting to `false`

depends on https://github.com/Maxopoly/KiraBukkitGateway/pull/1